### PR TITLE
slight tweaks to input handling to print help messages

### DIFF
--- a/pkaani/run.py
+++ b/pkaani/run.py
@@ -47,6 +47,7 @@ def handle_arguments_pkaani():
         opts, args = getopt.getopt(sys.argv[1:], "hi:", ["help","inp="])
     except getopt.GetoptError:
         usage_pkaani()
+        sys.exit(-1)
 		
     for opt, arg in opts:
 	
@@ -61,6 +62,9 @@ def handle_arguments_pkaani():
         else:
             assert False, usage_pkaani()
 
+    if inp_file is None:
+        usage_pkaani()
+        sys.exit(-1)
     # Input PDB file is mandatory!
     if len(inp_file)==0: # is None:
         print("@> ERROR: A PDB file is mandatory!")


### PR DESCRIPTION
I noticed that in the existing code, when you run `pkaani` with no arguments you get the error pasted at the bottom of this message. When you run `pkaani -i` with no PDB file you get the help message but also the error pasted at the bottom. I made a couple very small tweaks to make it so that the help message gets printed and the program exits when you either run `pkaani` with no input flags or `pkaani -i` with no PDB file. 

> 
>  File "/Users/sastrys1/opt/anaconda3/envs/pkaani/bin/pkaani", line 33, in <module>
>     sys.exit(load_entry_point('pkaani==0.1.0', 'console_scripts', 'pkaani')())
>   File "/Users/sastrys1/opt/anaconda3/envs/pkaani/lib/python3.8/site-packages/pkaani-0.1.0-py3.8.egg/pkaani/run.py", line 77, in main
>     input_files = handle_arguments_pkaani()   
>   File "/Users/sastrys1/opt/anaconda3/envs/pkaani/lib/python3.8/site-packages/pkaani-0.1.0-py3.8.egg/pkaani/run.py", line 68, in handle_arguments_pkaani
>     if len(inp_file)==0: # is None:
> TypeError: object of type 'NoneType' has no len()
